### PR TITLE
Port CTLs

### DIFF
--- a/starky/src/cross_table_lookup.rs
+++ b/starky/src/cross_table_lookup.rs
@@ -1,0 +1,552 @@
+#![allow(clippy::all)]
+
+/// An implementation of Hermez's "domain-free" cross-table lookup
+/// this differes from the main cross-table lookup in `evm` where
+/// the "looking" table does not have to be at least as long as the "looked" table
+/// paper: https://eprint.iacr.org/2022/1050
+
+use anyhow::{anyhow, Result};
+use itertools::Itertools;
+use plonky2::field::extension::{Extendable, FieldExtension};
+use plonky2::field::packed::PackedField;
+use plonky2::field::polynomial::PolynomialValues;
+use plonky2::field::types::Field;
+use plonky2::hash::hash_types::RichField;
+use plonky2::iop::challenger::Challenger;
+use plonky2::plonk::config::{GenericConfig, Hasher};
+
+use crate::config::StarkConfig;
+use crate::consumer::{Consumer, FilteredConsumer};
+use crate::consumer::basic::ConstraintConsumer;
+use crate::ir::{Registers, FirstRow, LastRow, Transition};
+use crate::proof::{StarkProof, StarkProofWithPublicInputs};
+use crate::stark::Stark;
+
+/// represets a set of cross-table lookups to be performed between an arbitrary number of starks on arbitrary sets of colums
+#[derive(Debug, Clone)]
+pub struct CtlDescriptor {
+    /// instances of CTLs, where a colset in one table "looks up" a column in another table
+    /// represented as pairs of columns where the LHS is a set of columns in some table "looking" up the RHS, another set of columns in some table
+    pub instances: Vec<(CtlColSet, CtlColSet)>,
+    /// the number of tables involved
+    pub num_tables: usize,
+}
+
+impl CtlDescriptor {
+    pub fn from_instances(instances: Vec<(CtlColSet, CtlColSet)>, num_tables: usize) -> Self {
+        Self {
+            instances,
+            num_tables,
+        }
+    }
+}
+
+/// Describes a set of columns that is involved in a cross-table lookup
+/// These columns are "linked" together via a linear-combination. This
+/// means the lookup effectively amounts to looking up a "tuple"
+/// of columns up to the *same* permutations. In other words,
+/// if a set of colums (a, b, c) in trace 0 is "looking up"
+/// a set of columns in (x, y, z) in trace 1, then the lookup will
+/// enforce that, for every row i in trace 0, there exists a row j in trace 1
+/// such that (a[i], b[i], c[i]) = (x[j], y[j], z[j]).
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub struct CtlColSet {
+    /// table ID for the table that this column set belongs to
+    pub(crate) tid: TableID,
+    /// set of column indices for this side of the CTL
+    pub(crate) colset: Vec<usize>,
+    /// column index for the corresponding filter, if any
+    pub(crate) filter_col: Option<usize>,
+}
+
+impl CtlColSet {
+    pub fn new(tid: TableID, colset: Vec<usize>, filter_col: Option<usize>) -> CtlColSet {
+        CtlColSet {
+            tid,
+            colset,
+            filter_col,
+        }
+    }
+}
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
+#[repr(transparent)]
+pub struct TableID(pub usize);
+
+impl From<usize> for TableID {
+    fn from(id: usize) -> Self {
+        TableID(id)
+    }
+}
+
+impl From<TableID> for usize {
+    fn from(id: TableID) -> Self {
+        id.0
+    }
+}
+
+// challenges used to reduce a set of columns to a single polynomial
+// against which the CTL is performed
+#[derive(Debug, Copy, Clone)]
+pub struct CtlLinearCombChallenge<F: Field> {
+    pub(crate) alpha: F,
+    pub(crate) gamma: F,
+}
+
+pub(crate) fn get_ctl_linear_comb_challenge<F: RichField, H: Hasher<F>>(
+    challenger: &mut Challenger<F, H>,
+) -> CtlLinearCombChallenge<F> {
+    CtlLinearCombChallenge {
+        alpha: challenger.get_challenge(),
+        gamma: challenger.get_challenge(),
+    }
+}
+
+// challenges used to compute the lookup's Z polys against the reduced colset poly
+#[derive(Debug, Copy, Clone)]
+pub struct CtlChallenge<F: Field> {
+    pub(crate) gamma: F,
+}
+
+pub(crate) fn get_ctl_challenge<F: RichField, H: Hasher<F>>(
+    challenger: &mut Challenger<F, H>,
+) -> CtlChallenge<F> {
+    CtlChallenge {
+        gamma: challenger.get_challenge(),
+    }
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct CtlColsetData<F: Field> {
+    // the set of columns
+    pub(crate) colset: CtlColSet,
+    // the Z poly for the CTL
+    // there are `num_challenges` of them
+    pub(crate) z_polys: Vec<PolynomialValues<F>>,
+    // the challenges used to reduce the colset into a single polynomial
+    // there are `num_challenges` of them
+    pub(crate) linear_comb_challenges: Vec<CtlLinearCombChallenge<F>>,
+    // the challenges used to compute the Z polys against the reduced polys
+    // there are `num_challenges` of them
+    pub(crate) ctl_challenges: Vec<CtlChallenge<F>>,
+}
+
+#[derive(Debug, Clone)]
+pub struct CtlData<F: Field> {
+    pub by_table: Vec<CtlTableData<F>>,
+}
+
+#[derive(Debug, Clone)]
+pub struct CtlTableData<F: Field> {
+    pub(crate) looking: Vec<CtlColsetData<F>>,
+    pub(crate) looked: Vec<CtlColsetData<F>>,
+}
+
+impl<F: Field> CtlTableData<F> {
+    pub(crate) fn zs(&self) -> Vec<PolynomialValues<F>> {
+        let mut zs = Vec::new();
+        for colset in self.looking.iter().chain(self.looked.iter()) {
+            zs.extend(colset.z_polys.iter().cloned());
+        }
+
+        zs
+    }
+
+    pub(crate) fn num_zs(&self) -> usize {
+        self.looking
+            .iter()
+            .chain(self.looked.iter())
+            .map(|colset| colset.z_polys.len())
+            .sum()
+    }
+
+    pub(crate) fn challenges(&self) -> (Vec<CtlLinearCombChallenge<F>>, Vec<CtlChallenge<F>>) {
+        let mut linear_comb_challenges = Vec::new();
+        let mut ctl_challenges = Vec::new();
+        for colset in self.looking.iter().chain(self.looked.iter()) {
+            linear_comb_challenges.extend(colset.linear_comb_challenges.iter().cloned());
+            ctl_challenges.extend(colset.ctl_challenges.iter().cloned());
+        }
+
+        (linear_comb_challenges, ctl_challenges)
+    }
+
+    pub(crate) fn cols(&self) -> Vec<CtlColSet> {
+        let mut cols = Vec::new();
+        for colset in self.looking.iter().chain(self.looked.iter()) {
+            cols.push(colset.colset.clone());
+        }
+
+        cols
+    }
+}
+
+// compute the preprocessed polynomials necessary for the lookup argument given CTL traces and table descriptors
+pub fn get_ctl_data<F: RichField + Extendable<D>, C: GenericConfig<D, F = F>, const D: usize>(
+    config: &StarkConfig,
+    trace_poly_valueses: &[Vec<PolynomialValues<F>>],
+    ctl_descriptor: &CtlDescriptor,
+    challenger: &mut Challenger<F, C::Hasher>,
+) -> CtlData<F> {
+    let num_challenges = config.num_challenges;
+
+    let mut by_table = vec![
+        CtlTableData {
+            looking: Vec::new(),
+            looked: Vec::new()
+        };
+        ctl_descriptor.num_tables
+    ];
+
+    for (looking_colset, looked_colset) in ctl_descriptor.instances.iter() {
+        let CtlColSet {
+            tid: looking_tid,
+            colset: looking_cols,
+            filter_col: looking_filter_col,
+        } = looking_colset.clone();
+
+        let CtlColSet {
+            tid: looked_tid,
+            colset: looked_cols,
+            filter_col: looked_filter_col,
+        } = looked_colset.clone();
+
+        let linear_comb_challenges = (0..num_challenges)
+            .map(|_| get_ctl_linear_comb_challenge(challenger))
+            .collect_vec();
+
+        let ctl_challenges = (0..num_challenges)
+            .map(|_| get_ctl_challenge(challenger))
+            .collect_vec();
+
+        let looking_filter_poly =
+            looking_filter_col.map(|col| &trace_poly_valueses[looking_tid.0][col]);
+        let looking_colset_polys = looking_cols
+            .iter()
+            .map(|&col| &trace_poly_valueses[looking_tid.0][col])
+            .collect_vec();
+        let looking_z_polys = linear_comb_challenges
+            .iter()
+            .zip(ctl_challenges.iter())
+            .map(|(linear_comb_challenge, challenge)| {
+                compute_z_poly(
+                    &looking_colset_polys,
+                    looking_filter_poly,
+                    linear_comb_challenge,
+                    challenge,
+                )
+            })
+            .collect_vec();
+
+        let looked_filter_poly =
+            looked_filter_col.map(|col| &trace_poly_valueses[looked_tid.0][col]);
+        let looked_colset_polys = looked_cols
+            .iter()
+            .map(|&col| &trace_poly_valueses[looked_tid.0][col])
+            .collect_vec();
+        let looked_z_polys = linear_comb_challenges
+            .iter()
+            .zip(ctl_challenges.iter())
+            .map(|(linear_comb_challenge, challenge)| {
+                compute_z_poly(
+                    &looked_colset_polys,
+                    looked_filter_poly,
+                    linear_comb_challenge,
+                    challenge,
+                )
+            })
+            .collect_vec();
+
+        let looking_data = CtlColsetData {
+            colset: looking_colset.clone(),
+            z_polys: looking_z_polys,
+            linear_comb_challenges: linear_comb_challenges.clone(),
+            ctl_challenges: ctl_challenges.clone(),
+        };
+
+        let looked_data = CtlColsetData {
+            colset: looked_colset.clone(),
+            z_polys: looked_z_polys,
+            linear_comb_challenges,
+            ctl_challenges,
+        };
+
+        by_table[looking_tid.0].looking.push(looking_data);
+        by_table[looked_tid.0].looked.push(looked_data);
+    }
+
+    CtlData { by_table }
+}
+
+fn compute_z_poly<F: Field>(
+    colset_polys: &[&PolynomialValues<F>],
+    selector_poly: Option<&PolynomialValues<F>>,
+    linear_comb_challenge: &CtlLinearCombChallenge<F>,
+    challenge: &CtlChallenge<F>,
+) -> PolynomialValues<F> {
+    let &CtlLinearCombChallenge { gamma, alpha } = linear_comb_challenge;
+    let eval_reduced = |row: usize| {
+        let mut eval = F::ZERO;
+        for &poly in colset_polys {
+            eval = eval * alpha + poly.values[row];
+        }
+        eval + gamma
+    };
+
+    let &CtlChallenge { gamma } = challenge;
+    if let Some(selector_poly) = selector_poly {
+        let mut evals = Vec::new();
+        let mut eval = F::ONE;
+        for i in (0..selector_poly.len()).filter(|&i| selector_poly.values[i] != F::ZERO) {
+            debug_assert!(selector_poly.values[i] == F::ONE, "non-binary filter");
+
+            evals.resize(i, eval);
+
+            eval *= eval_reduced(i) + gamma;
+            evals.push(eval);
+        }
+        evals.resize(selector_poly.len(), eval);
+        PolynomialValues::new(evals)
+    } else {
+        let evals = (0..colset_polys[0].len())
+            .map(eval_reduced)
+            .scan(F::ONE, |eval, reduced_eval| {
+                *eval *= reduced_eval + gamma;
+                Some(*eval)
+            })
+            .collect_vec();
+        PolynomialValues::new(evals)
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct CtlCheckVars<F, FE, P, const D2: usize>
+where
+    F: Field,
+    FE: FieldExtension<D2, BaseField = F>,
+    P: PackedField<Scalar = FE>,
+{
+    pub(crate) local_zs: Vec<P>,
+    pub(crate) next_zs: Vec<P>,
+    pub(crate) first_zs: Vec<F>,
+    pub(crate) last_zs: Vec<F>,
+    pub(crate) linear_comb_challenges: Vec<CtlLinearCombChallenge<F>>,
+    pub(crate) challenges: Vec<CtlChallenge<F>>,
+    pub(crate) cols: Vec<CtlColSet>,
+}
+
+impl<F, const D: usize> CtlCheckVars<F, F::Extension, F::Extension, D>
+where
+    F: RichField + Extendable<D>,
+{
+    pub fn from_proofs<C: GenericConfig<D, F = F>>(
+        proofs: &[StarkProofWithPublicInputs<F, C, D>],
+        ctl_descriptor: &CtlDescriptor,
+        linear_comb_challenges_by_table: &[Vec<CtlLinearCombChallenge<F>>],
+        ctl_challenges_by_table: &[Vec<CtlChallenge<F>>],
+    ) -> Vec<Self> {
+        let num_tables = ctl_descriptor.num_tables;
+        debug_assert_eq!(num_tables, proofs.len());
+
+        let first_last_zs = proofs.iter().map(|p| {
+            (
+                p.proof
+                    .openings
+                    .ctl_zs_first
+                    .as_ref()
+                    .expect("no ctl first opening!")
+                    .clone(),
+                p.proof
+                    .openings
+                    .ctl_zs_last
+                    .as_ref()
+                    .expect("no ctl last opening!")
+                    .clone(),
+            )
+        });
+        let ctl_zs = proofs
+            .iter()
+            .map(|p| {
+                let openings = &p.proof.openings;
+                let ctl_zs = openings.ctl_zs.as_ref().expect("no ctl openings!").iter();
+                let ctl_zs_next = openings
+                    .ctl_zs_next
+                    .as_ref()
+                    .expect("no ctl openings!")
+                    .iter();
+                ctl_zs.zip(ctl_zs_next)
+            })
+            .collect_vec();
+
+        // (looking, looked) by table
+        let mut instances_by_table = vec![(Vec::new(), Vec::new()); num_tables];
+        for (looking, looked) in ctl_descriptor.instances.iter() {
+            instances_by_table[looking.tid.0].0.push(looking);
+            instances_by_table[looked.tid.0].1.push(looked);
+        }
+
+        let instances_by_table = instances_by_table
+            .iter()
+            .map(|(looking, looked)| looking.iter().chain(looked.iter()));
+
+        instances_by_table
+            .zip(first_last_zs.zip(ctl_zs))
+            .zip(
+                linear_comb_challenges_by_table
+                    .iter()
+                    .zip(ctl_challenges_by_table.iter()),
+            )
+            .map(
+                |(
+                    (instances, ((first_zs, last_zs), ctl_zs)),
+                    (linear_comb_challenges, ctl_challenges),
+                )| {
+                    let cols = instances.map(|&x| x.clone()).collect_vec();
+                    let (local_zs, next_zs) = ctl_zs.unzip();
+
+                    let challenges = ctl_challenges.clone();
+                    let linear_comb_challenges = linear_comb_challenges.clone();
+
+                    CtlCheckVars {
+                        local_zs,
+                        next_zs,
+                        first_zs,
+                        last_zs,
+                        linear_comb_challenges,
+                        challenges,
+                        cols,
+                    }
+                },
+            )
+            .collect_vec()
+    }
+}
+
+pub(crate) fn eval_cross_table_lookup_checks<F, FE, P, C, S, const D: usize, const D2: usize>(
+    vars: Registers<P>,
+    ctl_vars: &CtlCheckVars<F, FE, P, D2>,
+    consumer: &mut ConstraintConsumer<P>,
+    num_challenges: usize,
+) where
+    F: RichField + Extendable<D>,
+    FE: FieldExtension<D2, BaseField = F>,
+    P: PackedField<Scalar = FE>,
+    C: GenericConfig<D, F = F>,
+    S: Stark<P, ConstraintConsumer<P>>,
+{
+    debug_assert_eq!(
+        ctl_vars.challenges.len(),
+        num_challenges * ctl_vars.cols.len()
+    );
+
+    let eval_reduced = |evals: &[P], alpha: F, gamma: F| {
+        let mut sum = P::ZEROS;
+        for &eval in evals {
+            sum = sum * FE::from_basefield(alpha) + eval
+        }
+        sum + FE::from_basefield(gamma)
+    };
+
+    for instance in 0..ctl_vars.cols.len() {
+        let colset = &ctl_vars.cols[instance];
+        let filter_col = colset.filter_col;
+        let local_ctl_col_values = colset
+            .colset
+            .iter()
+            .map(|&col| vars.local_values[col])
+            .collect_vec();
+        let next_ctl_col_values = colset
+            .colset
+            .iter()
+            .map(|&col| vars.next_values[col])
+            .collect_vec();
+
+        let sel = filter_col.map_or(P::ONES, |col| vars.local_values[col]);
+        // check filter is binary
+        consumer.constraint(sel * (P::ONES - sel), &mut ());
+
+        let next_sel = filter_col.map_or(P::ONES, |col| vars.next_values[col]);
+
+        for i in 0..num_challenges {
+            let linear_comb_challenge =
+                &ctl_vars.linear_comb_challenges[instance * num_challenges + i];
+            let challenge = &ctl_vars.challenges[instance * num_challenges + i];
+            let local_z = ctl_vars.local_zs[instance * num_challenges + i];
+            let next_z = ctl_vars.next_zs[instance * num_challenges + i];
+            let first_z = ctl_vars.first_zs[instance * num_challenges + i];
+            let last_z = ctl_vars.last_zs[instance * num_challenges + i];
+
+            // check first and last zs
+            consumer.constraint_filtered(FirstRow, local_z - FE::from_basefield(first_z), &mut ());
+            consumer.constraint_filtered(LastRow, local_z - FE::from_basefield(last_z),  &mut ());
+
+            // check grand product
+            let reduced_eval = eval_reduced(
+                &next_ctl_col_values,
+                linear_comb_challenge.alpha,
+                linear_comb_challenge.gamma,
+            );
+            let eval = reduced_eval + FE::from_basefield(challenge.gamma) - P::ONES;
+            consumer.constraint_filtered(Transition, next_z - (local_z * (next_sel * eval + P::ONES)), &mut ());
+            consumer.constraint_filtered(LastRow, next_z - FE::from_basefield(first_z), &mut ());
+
+            // check grand product start
+            let reduced_eval = eval_reduced(
+                &local_ctl_col_values,
+                linear_comb_challenge.alpha,
+                linear_comb_challenge.gamma,
+            );
+            let eval = reduced_eval + FE::from_basefield(challenge.gamma) - P::ONES;
+            consumer.constraint_filtered(FirstRow, (sel * eval + P::ONES) - FE::from_basefield(first_z), &mut ());
+        }
+    }
+}
+
+pub fn verify_cross_table_lookups<
+    'a,
+    I: Iterator<Item = &'a StarkProof<F, C, D>>,
+    F: RichField + Extendable<D>,
+    C: GenericConfig<D, F = F> + 'a,
+    const D: usize,
+>(
+    proofs: I,
+    descriptor: &CtlDescriptor,
+    num_challenges: usize,
+) -> Result<()> {
+    let ctl_zs_openings = proofs
+        .flat_map(|p| p.openings.ctl_zs_last.iter())
+        .collect_vec();
+
+    let mut looking_zs = Vec::new();
+    let mut looked_zs = Vec::new();
+    let mut indices = vec![0; descriptor.num_tables];
+    for (looking, _) in descriptor.instances.iter() {
+        let tid = looking.tid;
+        let idx = indices[tid.0];
+        let zs = &ctl_zs_openings[tid.0][idx..idx + num_challenges];
+        indices[tid.0] += num_challenges;
+        looking_zs.extend(zs.iter().map(move |z| (z, tid)));
+    }
+
+    for (_, looked) in descriptor.instances.iter() {
+        let tid = looked.tid;
+        let idx = indices[tid.0];
+        let zs = &ctl_zs_openings[tid.0][idx..idx + num_challenges];
+        indices[tid.0] += num_challenges;
+        looked_zs.extend(zs.iter().map(move |z| (z, tid)));
+    }
+
+    for ((looking_z, looking_tid), (looked_z, looked_tid)) in
+        looking_zs.into_iter().zip(looked_zs.into_iter())
+    {
+        if looking_z != looked_z {
+            let msg = format!(
+                "cross table lookup verification failed. looking TableID: {}, looked TableID: {}, looking_z: {:?}, looked_z: {:?}",
+                looking_tid.0, looked_tid.0, looking_z, looked_z
+            );
+            return Err(anyhow!(msg));
+        }
+    }
+
+    Ok(())
+}

--- a/starky/src/cross_table_lookup.rs
+++ b/starky/src/cross_table_lookup.rs
@@ -463,7 +463,7 @@ pub(crate) fn eval_cross_table_lookup_checks<F, FE, P, C, S, const D: usize, con
 
         let sel = filter_col.map_or(P::ONES, |col| vars.local_values[col]);
         // check filter is binary
-        consumer.constraint(sel * (P::ONES - sel), &mut ());
+        consumer.constraint(&(sel * (P::ONES - sel)), &mut ());
 
         let next_sel = filter_col.map_or(P::ONES, |col| vars.next_values[col]);
 
@@ -477,8 +477,8 @@ pub(crate) fn eval_cross_table_lookup_checks<F, FE, P, C, S, const D: usize, con
             let last_z = ctl_vars.last_zs[instance * num_challenges + i];
 
             // check first and last zs
-            consumer.constraint_filtered(FirstRow, local_z - FE::from_basefield(first_z), &mut ());
-            consumer.constraint_filtered(LastRow, local_z - FE::from_basefield(last_z),  &mut ());
+            consumer.constraint_filtered(FirstRow, &(local_z - FE::from_basefield(first_z)), &mut ());
+            consumer.constraint_filtered(LastRow, &(local_z - FE::from_basefield(last_z)),  &mut ());
 
             // check grand product
             let reduced_eval = eval_reduced(
@@ -487,8 +487,8 @@ pub(crate) fn eval_cross_table_lookup_checks<F, FE, P, C, S, const D: usize, con
                 linear_comb_challenge.gamma,
             );
             let eval = reduced_eval + FE::from_basefield(challenge.gamma) - P::ONES;
-            consumer.constraint_filtered(Transition, next_z - (local_z * (next_sel * eval + P::ONES)), &mut ());
-            consumer.constraint_filtered(LastRow, next_z - FE::from_basefield(first_z), &mut ());
+            consumer.constraint_filtered(Transition, &(next_z - (local_z * (next_sel * eval + P::ONES))), &mut ());
+            consumer.constraint_filtered(LastRow, &(next_z - FE::from_basefield(first_z)), &mut ());
 
             // check grand product start
             let reduced_eval = eval_reduced(
@@ -497,7 +497,7 @@ pub(crate) fn eval_cross_table_lookup_checks<F, FE, P, C, S, const D: usize, con
                 linear_comb_challenge.gamma,
             );
             let eval = reduced_eval + FE::from_basefield(challenge.gamma) - P::ONES;
-            consumer.constraint_filtered(FirstRow, (sel * eval + P::ONES) - FE::from_basefield(first_z), &mut ());
+            consumer.constraint_filtered(FirstRow, &((sel * eval + P::ONES) - FE::from_basefield(first_z)), &mut ());
         }
     }
 }

--- a/starky/src/get_challenges.rs
+++ b/starky/src/get_challenges.rs
@@ -1,5 +1,6 @@
 use alloc::vec::Vec;
 
+use itertools::Itertools;
 use plonky2::field::extension::Extendable;
 use plonky2::field::polynomial::PolynomialCoeffs;
 use plonky2::fri::proof::{FriProof, FriProofTarget};
@@ -12,14 +13,147 @@ use plonky2::plonk::circuit_builder::CircuitBuilder;
 use plonky2::plonk::config::{AlgebraicHasher, GenericConfig};
 
 use crate::config::StarkConfig;
+use crate::cross_table_lookup::{CtlDescriptor, CtlLinearCombChallenge, CtlChallenge, get_ctl_linear_comb_challenge, get_ctl_challenge};
 use crate::permutation::{
     get_n_permutation_challenge_sets, get_n_permutation_challenge_sets_target,
 };
 use crate::proof::*;
 use crate::stark::StarkConfiguration;
 
+// makes a challenger and overves the trace caps
+pub fn start_all_proof_challenger<'a, F, C, I, const D: usize>(
+    trace_caps: I,
+) -> Challenger<F, C::Hasher>
+where
+    I: Iterator<Item = &'a MerkleCap<F, C::Hasher>>,
+    F: RichField + Extendable<D>,
+    C: GenericConfig<D, F = F>,
+    <C as GenericConfig<D>>::Hasher: 'a,
+{
+    let mut challenger = Challenger::<F, C::Hasher>::new();
+
+    for cap in trace_caps {
+        challenger.observe_cap(cap);
+    }
+
+    challenger
+}
+
+// assumes `start_all_proof_challenges` was used to get the challenger
+pub fn get_ctl_challenges_by_table<F, C, const D: usize>(
+    challenger: &mut Challenger<F, C::Hasher>,
+    ctl_descriptor: &CtlDescriptor,
+    num_challenges: usize,
+) -> (
+    Vec<Vec<CtlLinearCombChallenge<F>>>,
+    Vec<Vec<CtlChallenge<F>>>,
+)
+where
+    F: RichField + Extendable<D>,
+    C: GenericConfig<D, F = F>,
+{
+    let mut linear_comb_challenges_by_table =
+        vec![(Vec::new(), Vec::new()); ctl_descriptor.num_tables];
+    let mut ctl_challenges_by_table = vec![(Vec::new(), Vec::new()); ctl_descriptor.num_tables];
+    for (looking, looked) in ctl_descriptor.instances.iter() {
+        let linear_comb_challenges = (0..num_challenges)
+            .map(|_| get_ctl_linear_comb_challenge(challenger))
+            .collect_vec();
+
+        let ctl_challenges = (0..num_challenges)
+            .map(|_| get_ctl_challenge(challenger))
+            .collect_vec();
+
+        linear_comb_challenges_by_table[looking.tid.0]
+            .0
+            .extend(linear_comb_challenges.clone());
+        linear_comb_challenges_by_table[looked.tid.0]
+            .1
+            .extend(linear_comb_challenges);
+
+        ctl_challenges_by_table[looking.tid.0]
+            .0
+            .extend(ctl_challenges.clone());
+        ctl_challenges_by_table[looked.tid.0]
+            .1
+            .extend(ctl_challenges);
+    }
+
+    let linear_comb_challenges_by_table = linear_comb_challenges_by_table
+        .into_iter()
+        .map(|(looking, looked)| [looking, looked].concat())
+        .collect_vec();
+
+    let ctl_challenges_by_table = ctl_challenges_by_table
+        .into_iter()
+        .map(|(looking, looked)| [looking, looked].concat())
+        .collect_vec();
+
+    (linear_comb_challenges_by_table, ctl_challenges_by_table)
+}
+
+// IMPORTANT: assumes `challenger` has already observed the trace caps and the ctl challenges have already been extracted
+fn get_single_table_challenges<F, C, S, const D: usize>(
+    stark: &S,
+    challenger: &mut Challenger<F, C::Hasher>,
+    permutation_zs_cap: Option<&MerkleCap<F, C::Hasher>>,
+    ctl_zs_cap: Option<&MerkleCap<F, C::Hasher>>,
+    quotient_polys_cap: &MerkleCap<F, C::Hasher>,
+    openings: &StarkOpeningSet<F, D>,
+    commit_phase_merkle_caps: &[MerkleCap<F, C::Hasher>],
+    final_poly: &PolynomialCoeffs<F::Extension>,
+    pow_witness: F,
+    config: &StarkConfig,
+    degree_bits: usize,
+) -> StarkProofChallenges<F, D>
+where
+    F: RichField + Extendable<D>,
+    C: GenericConfig<D, F = F>,
+    S: StarkConfiguration,
+{
+    let num_challenges = config.num_challenges;
+    let metadata = stark.metadata();
+
+    let permutation_challenge_sets = permutation_zs_cap.map(|permutation_zs_cap| {
+        let tmp = get_n_permutation_challenge_sets(
+            challenger,
+            num_challenges,
+            metadata.permutation_batch_size(),
+        );
+        challenger.observe_cap(permutation_zs_cap);
+        tmp
+    });
+
+    if let Some(cap) = ctl_zs_cap {
+        challenger.observe_cap(cap);
+    }
+
+    let stark_alphas = challenger.get_n_challenges(num_challenges);
+
+    challenger.observe_cap(quotient_polys_cap);
+
+    let stark_zeta = challenger.get_extension_challenge::<D>();
+
+    challenger.observe_openings(&openings.to_fri_openings());
+
+    let fri_challenges = challenger.fri_challenges::<C, D>(
+        commit_phase_merkle_caps,
+        final_poly,
+        pow_witness,
+        degree_bits,
+        &config.fri_config,
+    );
+
+    StarkProofChallenges {
+        permutation_challenge_sets,
+        stark_alphas,
+        stark_zeta,
+        fri_challenges,
+    }
+}
+
 #[allow(clippy::too_many_arguments)] // NOTE: Clippy is too harsh here.
-fn get_challenges<F, C, S, const D: usize>(
+fn get_stark_challenges<F, C, S, const D: usize>(
     stark: &S,
     trace_cap: &MerkleCap<F, C::Hasher>,
     permutation_zs_cap: Option<&MerkleCap<F, C::Hasher>>,
@@ -80,7 +214,7 @@ where
 {
     // TODO: Should be used later in compression?
     #![allow(dead_code)]
-    pub(crate) fn fri_query_indices<S>(
+    pub(crate) fn fri_query_indices_no_ctl<S>(
         &self,
         stark: &S,
         config: &StarkConfig,
@@ -89,13 +223,13 @@ where
     where
         S: StarkConfiguration,
     {
-        self.get_challenges(stark, config, degree_bits)
+        self.get_stark_challenges_no_ctl(stark, config, degree_bits)
             .fri_challenges
             .fri_query_indices
     }
 
     /// Computes all Fiat-Shamir challenges used in the STARK proof.
-    pub(crate) fn get_challenges<S>(
+    pub(crate) fn get_stark_challenges_no_ctl<S>(
         &self,
         stark: &S,
         config: &StarkConfig,
@@ -107,6 +241,7 @@ where
         let StarkProof {
             trace_cap,
             permutation_zs_cap,
+            ctl_zs_cap,
             quotient_polys_cap,
             openings,
             opening_proof:
@@ -117,10 +252,54 @@ where
                     ..
                 },
         } = &self.proof;
-        get_challenges::<F, C, S, D>(
+
+        assert!(
+            ctl_zs_cap.is_none(),
+            "CTLs not supported in `get_stark_challenges_no_ctl`"
+        );
+
+        get_stark_challenges::<F, C, S, D>(
             stark,
             trace_cap,
             permutation_zs_cap.as_ref(),
+            quotient_polys_cap,
+            openings,
+            commit_phase_merkle_caps,
+            final_poly,
+            *pow_witness,
+            config,
+            degree_bits,
+        ) 
+    }
+
+    /// Computes Fiat-Shamir challenges for this specific proof within an `AllProof`
+    pub(crate) fn get_stark_challenges_with_ctl<S: StarkConfiguration>(
+        &self,
+        stark: &S,
+        config: &StarkConfig,
+        challenger: &mut Challenger<F, C::Hasher>,
+        degree_bits: usize,
+    ) -> StarkProofChallenges<F, D> {
+        let StarkProof {
+            trace_cap: _,
+            permutation_zs_cap,
+            ctl_zs_cap,
+            quotient_polys_cap,
+            openings,
+            opening_proof:
+                FriProof {
+                    commit_phase_merkle_caps,
+                    final_poly,
+                    pow_witness,
+                    ..
+                },
+        } = &self.proof;
+
+        get_single_table_challenges::<F, C, S, D>(
+            stark,
+            challenger,
+            permutation_zs_cap.as_ref(),
+            ctl_zs_cap.as_ref(),
             quotient_polys_cap,
             openings,
             commit_phase_merkle_caps,

--- a/starky/src/lib.rs
+++ b/starky/src/lib.rs
@@ -22,6 +22,7 @@ pub mod starks;
 pub mod util;
 pub mod vanishing_poly;
 pub mod verifier;
+pub mod cross_table_lookup;
 
 #[cfg(test)]
 pub mod fibonacci_stark;

--- a/starky/src/proof.rs
+++ b/starky/src/proof.rs
@@ -201,38 +201,34 @@ impl<F: RichField + Extendable<D>, const D: usize> StarkOpeningSet<F, D> {
                 .next_values
                 .iter()
                 .chain(self.permutation_zs_next.iter().flatten())
-                .chain(self.ctl_zs.iter().flatten())
+                .chain(self.ctl_zs_next.iter().flatten())
                 .copied()
                 .collect(),
         };
 
-        let ctl_first_last_batches = match (self.ctl_zs_first.as_ref(), self.ctl_zs_last.as_ref()) {
-            (Some(first), Some(last)) => {
-                let first_batch = FriOpeningBatch {
-                    values: first
-                        .iter()
-                        .copied()
-                        .map(F::Extension::from_basefield)
-                        .collect(),
-                };
-
-                let last_batch = FriOpeningBatch {
-                    values: last
-                        .iter()
-                        .copied()
-                        .map(F::Extension::from_basefield)
-                        .collect(),
-                };
-
-                Some((first_batch, last_batch))
-            }
-            (None, None) => None,
-            _ => panic!("ctl_zs_first.is_some() != ctl_zs_last.is_some()"),
-        };
-
         let mut batches = vec![zeta_batch, zeta_next_batch];
-        if let Some((first_batch, last_batch)) = ctl_first_last_batches {
+
+        assert!(self.ctl_zs_first.is_some() == self.ctl_zs_last.is_some());
+
+        if let Some(zs_first) = self.ctl_zs_first.as_ref() {
+            let first_batch = FriOpeningBatch {
+                values: zs_first
+                    .iter()
+                    .copied()
+                    .map(F::Extension::from_basefield)
+                    .collect(),
+            };
             batches.push(first_batch);
+        }
+
+        if let Some(zs_last) = self.ctl_zs_last.as_ref() {
+            let last_batch = FriOpeningBatch {
+                values: zs_last
+                    .iter()
+                    .copied()
+                    .map(F::Extension::from_basefield)
+                    .collect(),
+            };
             batches.push(last_batch);
         }
 

--- a/starky/src/prover.rs
+++ b/starky/src/prover.rs
@@ -205,7 +205,6 @@ where
         challenger.observe_cap(cap);
     }
 
-
     let ctl_zs_commitment_challenges_cols = ctl_data.map(|ctl_data| {
         let zs = ctl_data.zs();
         let commitment = timed!(

--- a/starky/src/prover.rs
+++ b/starky/src/prover.rs
@@ -19,6 +19,7 @@ use plonky2::util::{log2_ceil, log2_strict, transpose};
 
 use crate::config::StarkConfig;
 use crate::consumer::basic::ConstraintConsumer;
+use crate::cross_table_lookup::{CtlTableData, CtlCheckVars, CtlLinearCombChallenge, CtlChallenge, CtlColSet};
 use crate::ir::Registers;
 use crate::permutation::{
     compute_permutation_z_polys, get_n_permutation_challenge_sets, PermutationChallengeSet,
@@ -28,10 +29,65 @@ use crate::proof::{StarkOpeningSet, StarkProof, StarkProofWithPublicInputs};
 use crate::stark::Stark;
 use crate::vanishing_poly::eval_vanishing_poly;
 
-pub fn prove<F, C, S, const D: usize>(
-    stark: S,
+// Compute all STARK trace commitments.
+fn compute_trace_commitments<F, C, const D: usize>(
     config: &StarkConfig,
-    trace_poly_values: Vec<PolynomialValues<F>>,
+    trace_poly_values: &[Vec<PolynomialValues<F>>],
+    timing: &mut TimingTree,
+) -> Result<Vec<PolynomialBatch<F, C, D>>>
+where
+    F: RichField + Extendable<D>,
+    C: GenericConfig<D, F = F>,
+{
+    let rate_bits = config.fri_config.rate_bits;
+    let cap_height = config.fri_config.cap_height;
+
+    Ok(timed!(
+        timing,
+        "compute trace commitments",
+        trace_poly_values
+            .par_iter()
+            .cloned()
+            .map(|trace| {
+                let mut timing = TimingTree::default();
+                PolynomialBatch::<F, C, D>::from_values(
+                    // TODO: Cloning this isn't great; consider having `from_values` accept a reference,
+                    // or having `compute_permutation_z_polys` read trace values from the `PolynomialBatch`.
+                    trace,
+                    rate_bits,
+                    false,
+                    cap_height,
+                    &mut timing,
+                    None,
+                )
+            })
+            .collect::<Vec<_>>()
+    ))
+}
+
+/// Make a new challenger, compute all STARK trace commitments and observe them in the challenger
+pub fn start_multi_table_prover<F, C, const D: usize>(
+    config: &StarkConfig,
+    trace_poly_values: &[Vec<PolynomialValues<F>>],
+    timing: &mut TimingTree,
+) -> Result<(Vec<PolynomialBatch<F, C, D>>, Challenger<F, C::Hasher>)>
+where
+    F: RichField + Extendable<D>,
+    C: GenericConfig<D, F = F>,
+{
+    let trace_commitments = compute_trace_commitments(config, trace_poly_values, timing)?;
+    let mut challenger = Challenger::<F, C::Hasher>::new();
+    for cap in trace_commitments.iter().map(|c| &c.merkle_tree.cap) {
+        challenger.observe_cap(cap);
+    }
+
+    Ok((trace_commitments, challenger))
+}
+
+pub fn prove_no_ctl<F, C, S, const D: usize>(
+    stark: &S,
+    config: &StarkConfig,
+    trace_poly_values: &[PolynomialValues<F>],
     public_inputs: Vec<F>,
     timing: &mut TimingTree,
 ) -> Result<StarkProofWithPublicInputs<F, C, D>>
@@ -58,7 +114,7 @@ where
         PolynomialBatch::<F, C, D>::from_values(
             // TODO: Cloning this isn't great; consider having `from_values` accept a reference,
             // or having `compute_permutation_z_polys` read trace values from the `PolynomialBatch`.
-            trace_poly_values.clone(),
+            trace_poly_values.to_vec(),
             rate_bits,
             false,
             cap_height,
@@ -71,11 +127,51 @@ where
     let mut challenger = Challenger::new();
     challenger.observe_cap(&trace_cap);
 
+    prove_single_table(
+        stark,
+        config,
+        &trace_poly_values,
+        &trace_commitment,
+        None,
+        &public_inputs,
+        &mut challenger,
+        timing,
+    )
+}
+
+pub fn prove_single_table<F, C, S, const D: usize>(
+    stark: &S,
+    config: &StarkConfig,
+    trace_poly_values: &[PolynomialValues<F>],
+    trace_commitment: &PolynomialBatch<F, C, D>,
+    ctl_data: Option<&CtlTableData<F>>,
+    public_inputs: &[F],
+    challenger: &mut Challenger<F, C::Hasher>,
+    timing: &mut TimingTree,
+) -> Result<StarkProofWithPublicInputs<F, C, D>>
+where
+    F: RichField + Extendable<D>,
+    C: GenericConfig<D, F = F>,
+    S: Stark<F, ConstraintConsumer<F>>
+        + Stark<<F as Packable>::Packing, ConstraintConsumer<<F as Packable>::Packing>>
+        + Sync,
+{
+
+    let degree = trace_poly_values[0].len();
+    let degree_bits = log2_strict(degree);
+    let fri_params = config.fri_params(degree_bits);
+    let rate_bits = config.fri_config.rate_bits;
+    let cap_height = config.fri_config.cap_height;
+    assert!(
+        fri_params.total_arities() <= degree_bits + rate_bits - cap_height,
+        "FRI total reduction arity is too large.",
+    );
+
     // Permutation arguments.
     let permutation_zs_commitment_challenges =
         stark.metadata().uses_permutation_args().then(|| {
             let permutation_challenge_sets = get_n_permutation_challenge_sets(
-                &mut challenger,
+                challenger,
                 config.num_challenges,
                 stark.metadata().permutation_batch_size(),
             );
@@ -109,11 +205,42 @@ where
         challenger.observe_cap(cap);
     }
 
+
+    let ctl_zs_commitment_challenges_cols = ctl_data.map(|ctl_data| {
+        let zs = ctl_data.zs();
+        let commitment = timed!(
+            timing,
+            "compute CTL Z commitments",
+            PolynomialBatch::<F, C, D>::from_values(
+                zs,
+                rate_bits,
+                false,
+                config.fri_config.cap_height,
+                timing,
+                None
+            )
+        );
+        let challenges = ctl_data.challenges();
+        let cols = ctl_data.cols();
+        (commitment, challenges, cols)
+    });
+
+    let ctl_zs_commitment = ctl_zs_commitment_challenges_cols
+        .as_ref()
+        .map(|(comm, _, _)| comm);
+    let ctl_zs_cap = ctl_zs_commitment
+        .as_ref()
+        .map(|c| c.merkle_tree.cap.clone());
+    if let Some(cap) = &ctl_zs_cap {
+        challenger.observe_cap(cap);
+    }
+
     let alphas = challenger.get_n_challenges(config.num_challenges);
     let quotient_polys = compute_quotient_polys::<F, <F as Packable>::Packing, C, S, D>(
         &stark,
         &trace_commitment,
         &permutation_zs_commitment_challenges,
+        &ctl_zs_commitment_challenges_cols,
         &public_inputs,
         alphas,
         degree_bits,
@@ -158,12 +285,15 @@ where
         g,
         &trace_commitment,
         permutation_zs_commitment,
+        ctl_zs_commitment,
         &quotient_commitment,
+        degree_bits,
     );
     challenger.observe_openings(&openings.to_fri_openings());
 
-    let initial_merkle_trees = once(&trace_commitment)
+    let initial_merkle_trees = once(trace_commitment)
         .chain(permutation_zs_commitment)
+        .chain(ctl_zs_commitment)
         .chain(once(&quotient_commitment))
         .collect::<Vec<_>>();
 
@@ -171,16 +301,23 @@ where
         timing,
         "compute openings proof",
         PolynomialBatch::prove_openings(
-            &stark.metadata().fri_instance(zeta, g, config),
+            &stark.metadata().fri_instance(
+                zeta,
+                g,
+                config,
+                ctl_data.map(|data| data.num_zs()).unwrap_or(0),
+                degree_bits
+            ),
             &initial_merkle_trees,
-            &mut challenger,
+            challenger,
             &fri_params,
             timing,
         )
     );
     let proof = StarkProof {
-        trace_cap,
+        trace_cap: trace_commitment.merkle_tree.cap.clone(),
         permutation_zs_cap,
+        ctl_zs_cap,
         quotient_polys_cap,
         openings,
         opening_proof,
@@ -201,6 +338,11 @@ fn compute_quotient_polys<'a, F, P, C, S, const D: usize>(
     permutation_zs_commitment_challenges: &'a Option<(
         PolynomialBatch<F, C, D>,
         Vec<PermutationChallengeSet<F>>,
+    )>,
+    ctl_zs_commitment_challenges_cols: &'a Option<(
+        PolynomialBatch<F, C, D>,
+        (Vec<CtlLinearCombChallenge<F>>, Vec<CtlChallenge<F>>),
+        Vec<CtlColSet>,
     )>,
     public_inputs: &[F],
     alphas: Vec<F>,
@@ -245,6 +387,22 @@ where
         size,
     );
 
+    let ctl_zs_first_last = ctl_zs_commitment_challenges_cols.as_ref().map(|(c, _, _)| {
+        let mut ctl_zs_first = Vec::with_capacity(c.polynomials.len());
+        let mut ctl_zs_last = Vec::with_capacity(c.polynomials.len());
+        c.polynomials
+            .par_iter()
+            .map(|p| {
+                (
+                    p.eval(F::ONE),
+                    p.eval(F::primitive_root_of_unity(degree_bits).inverse()),
+                )
+            })
+            .unzip_into_vecs(&mut ctl_zs_first, &mut ctl_zs_last);
+
+        (ctl_zs_first, ctl_zs_last)
+    });
+
     // We will step by `P::WIDTH`, and in each iteration, evaluate the quotient polynomial at
     // a batch of `P::WIDTH` points.
     let quotient_values = (0..size)
@@ -281,11 +439,34 @@ where
                     permutation_challenge_sets: permutation_challenge_sets.to_vec(),
                 },
             );
+
+            let ctl_vars =
+            ctl_zs_commitment_challenges_cols
+                .as_ref()
+                .map(|(commitment, challenges, cols)| {
+                    let local_zs = commitment.get_lde_values_packed(i_start, step);
+                    let next_zs = commitment.get_lde_values_packed(i_next_start, step);
+                    let (linear_comb_challenges, challenges) = challenges.clone();
+                    let cols = cols.clone();
+                    let (first_zs, last_zs) = ctl_zs_first_last.clone().unwrap();
+
+                    CtlCheckVars {
+                        local_zs,
+                        next_zs,
+                        first_zs,
+                        last_zs,
+                        linear_comb_challenges,
+                        challenges,
+                        cols,
+                    }
+                });
+
             eval_vanishing_poly::<F, F, P, C, S, D, 1>(
                 stark,
                 config,
                 vars,
                 permutation_check_data,
+                ctl_vars.as_ref(),
                 &mut consumer,
             );
 

--- a/starky/src/stark.rs
+++ b/starky/src/stark.rs
@@ -1,7 +1,10 @@
 use alloc::vec;
 use alloc::vec::Vec;
 
-use plonky2::field::extension::{Extendable, FieldExtension};
+use plonky2::field::{
+    extension::{Extendable, FieldExtension},
+    types::Field,
+};
 use plonky2::fri::structure::{
     FriBatchInfo, FriBatchInfoTarget, FriInstanceInfo, FriInstanceInfoTarget, FriOracleInfo,
     FriPolynomialInfo,
@@ -170,6 +173,8 @@ impl StarkMetadata {
         zeta: F::Extension,
         g: F,
         config: &StarkConfig,
+        num_ctl_zs: usize,
+        degree_bits: usize,
     ) -> FriInstanceInfo<F, D>
     where
         F: RichField + Extendable<D>,
@@ -180,6 +185,7 @@ impl StarkMetadata {
             num_polys: self.columns,
             blinding: false,
         });
+
         let permutation_zs_info = if self.uses_permutation_args() {
             let num_z_polys = self.num_permutation_batches(config);
             let polys = FriPolynomialInfo::from_range(oracles.len(), 0..num_z_polys);
@@ -191,26 +197,58 @@ impl StarkMetadata {
         } else {
             vec![]
         };
+
         let num_quotient_polys = self.quotient_degree_factor() * config.num_challenges;
         let quotient_info = FriPolynomialInfo::from_range(oracles.len(), 0..num_quotient_polys);
         oracles.push(FriOracleInfo {
             num_polys: num_quotient_polys,
             blinding: false,
         });
+
+        let ctl_zs_oracle_info = if num_ctl_zs > 0 {
+            let polys = FriPolynomialInfo::from_range(oracles.len(), 0..num_ctl_zs);
+            oracles.push(FriOracleInfo {
+                num_polys: num_ctl_zs,
+                blinding: false,
+            });
+           polys 
+        } else {
+            vec![]
+        };
+
         let zeta_batch = FriBatchInfo {
             point: zeta,
             polynomials: [
                 trace_info.clone(),
                 permutation_zs_info.clone(),
+                ctl_zs_oracle_info.clone(),
                 quotient_info,
             ]
             .concat(),
         };
         let zeta_next_batch = FriBatchInfo {
             point: zeta.scalar_mul(g),
-            polynomials: [trace_info, permutation_zs_info].concat(),
+            polynomials: [trace_info, permutation_zs_info, ctl_zs_oracle_info.clone()].concat(),
         };
-        let batches = vec![zeta_batch, zeta_next_batch];
+
+
+        let mut batches = vec![zeta_batch, zeta_next_batch];
+
+        if ctl_zs_oracle_info.len() > 0 {
+            let zeta_first_batch = FriBatchInfo {
+                point: F::Extension::ONE,
+                polynomials: ctl_zs_oracle_info.clone()
+            };
+
+            let zeta_last_batch = FriBatchInfo {
+                point: F::Extension::primitive_root_of_unity(degree_bits).inverse(),
+                polynomials: ctl_zs_oracle_info
+            };
+
+            batches.push(zeta_first_batch);
+            batches.push(zeta_last_batch);
+        }
+
         FriInstanceInfo { oracles, batches }
     }
 

--- a/starky/src/stark.rs
+++ b/starky/src/stark.rs
@@ -248,7 +248,7 @@ impl StarkMetadata {
             batches.push(zeta_first_batch);
             batches.push(zeta_last_batch);
         }
-
+        
         FriInstanceInfo { oracles, batches }
     }
 

--- a/starky/src/starks/rw_memory/mod.rs
+++ b/starky/src/starks/rw_memory/mod.rs
@@ -69,10 +69,10 @@ mod tests {
 
     use super::*;
     use crate::config::StarkConfig;
-    use crate::prover::prove;
+    use crate::prover::prove_no_ctl;
     use crate::stark_testing::{test_stark_circuit_constraints, test_stark_low_degree};
     use crate::starks::rw_memory::generation::RwMemoryGenerator;
-    use crate::verifier::verify_stark_proof;
+    use crate::verifier::verify_stark_proof_no_ctl;
 
     #[test]
     fn test_stark() -> Result<()> {
@@ -121,8 +121,8 @@ mod tests {
         let stark = S::default();
         let trace = generator.into_polynomial_values();
         let mut timing = TimingTree::default();
-        let proof = prove::<F, C, S, D>(stark, &config, trace, vec![], &mut timing)?;
-        verify_stark_proof(stark, proof, &config)?;
+        let proof = prove_no_ctl::<F, C, S, D>(&stark, &config, &trace, vec![], &mut timing)?;
+        verify_stark_proof_no_ctl(&stark, proof, &config)?;
 
         Ok(())
     }

--- a/starky/src/starks/stack/mod.rs
+++ b/starky/src/starks/stack/mod.rs
@@ -68,10 +68,10 @@ mod tests {
 
     use super::*;
     use crate::config::StarkConfig;
-    use crate::prover::prove;
+    use crate::prover::prove_no_ctl;
     use crate::stark_testing::{test_stark_circuit_constraints, test_stark_low_degree};
     use crate::starks::stack::generation::StackGenerator;
-    use crate::verifier::verify_stark_proof;
+    use crate::verifier::verify_stark_proof_no_ctl;
 
     #[test]
     fn test_stark_degree() -> Result<()> {
@@ -122,8 +122,8 @@ mod tests {
         let stark = S::default();
         let trace = generator.into_polynomial_values();
         let mut timing = TimingTree::default();
-        let proof = prove::<F, C, S, D>(stark, &config, trace, vec![], &mut timing)?;
-        verify_stark_proof(stark, proof, &config)?;
+        let proof = prove_no_ctl::<F, C, S, D>(&stark, &config, &trace, vec![], &mut timing)?;
+        verify_stark_proof_no_ctl(&stark, proof, &config)?;
 
         Ok(())
     }

--- a/starky/src/starks/xor/mod.rs
+++ b/starky/src/starks/xor/mod.rs
@@ -236,9 +236,9 @@ mod tests {
 
     use super::*;
     use crate::config::StarkConfig;
-    use crate::prover::prove;
+    use crate::prover::prove_no_ctl;
     use crate::stark_testing::{test_stark_circuit_constraints, test_stark_low_degree};
-    use crate::verifier::verify_stark_proof;
+    use crate::verifier::verify_stark_proof_no_ctl;
 
     macro_rules! test_xor {
         ($n:expr, $fn_name:ident) => {
@@ -270,8 +270,8 @@ mod tests {
 
                     let trace = generator.into_polynomial_values();
                     let mut timing = TimingTree::default();
-                    let proof = prove::<F, C, S, D>(stark, &config, trace, vec![], &mut timing)?;
-                    verify_stark_proof(stark, proof, &config)
+                    let proof = prove_no_ctl::<F, C, S, D>(&stark, &config, &trace, vec![], &mut timing)?;
+                    verify_stark_proof_no_ctl(&stark, proof, &config)
                 }
             }
         };

--- a/starky/src/vanishing_poly.rs
+++ b/starky/src/vanishing_poly.rs
@@ -7,6 +7,7 @@ use plonky2::plonk::config::GenericConfig;
 
 use crate::config::StarkConfig;
 use crate::consumer::basic::{ConstraintConsumer, RecursiveConstraintConsumer};
+use crate::cross_table_lookup::CtlCheckVars;
 use crate::ir::Registers;
 use crate::permutation::{
     eval_permutation_checks, eval_permutation_checks_circuit, PermutationCheckDataTarget,
@@ -19,6 +20,7 @@ pub(crate) fn eval_vanishing_poly<F, FE, P, C, S, const D: usize, const D2: usiz
     config: &StarkConfig,
     registers: Registers<P>,
     permutation_data: Option<PermutationCheckVars<P, D2>>,
+    ctl_vars: Option<&CtlCheckVars<F, FE, P, D2>>,
     consumer: &mut ConstraintConsumer<P>,
 ) where
     F: RichField + Extendable<D>,


### PR DESCRIPTION
## Motivation

Need CTLs to do multi-stark config with memories

## Changes

- added `cross_table_lookup` module
- split `get_challenges` into variants with/without CTLs
- split `prove` into variants with/without CTLs with common `prove_single_table` method
- split `verify` into variants with/without CTLs
- updated existing tests to use `prove_no_ctl` instead of `prove` and they work.

NOTE: no test of the CTLs themselves was performed, as it depends on a proper multi-stark setup. In starky2, this was done with `AllStark`, but here we plan on doing something else.